### PR TITLE
Enable cf-mysql-release to be deployed without a CF

### DIFF
--- a/helpers/config.go
+++ b/helpers/config.go
@@ -13,7 +13,7 @@ type Component struct {
 }
 
 type Plan struct {
-	Name               string `json:"plan_name"`
+	Name               string `json:"name"`
 	MaxStorageMb       int    `json:"max_storage_mb"`
 	MaxUserConnections int    `json:"max_user_connections"`
 }
@@ -68,10 +68,6 @@ func ValidateConfig(config *MysqlIntegrationConfig) error {
 
 	if config.Plans == nil {
 		return fmt.Errorf("Field 'plans' must not be nil")
-	}
-
-	if len(config.Plans) == 0 {
-		return fmt.Errorf("Field 'plans' must not be empty")
 	}
 
 	for index, plan := range config.Plans {


### PR DESCRIPTION
Allow plans to be an empty array.

Preserve bosh manifest plan name property. This simplifies the JSON integration_config generation.

We're going to submit another PR against [cf-mysql-release](https://github.com/cloudfoundry/cf-mysql-release), both of these should be merged at the same time.