### PR TITLE
Add config option for broker protocol

### DIFF
--- a/cf-mysql-service/broker/broker_test.go
+++ b/cf-mysql-service/broker/broker_test.go
@@ -13,7 +13,7 @@ import (
 
 var _ = Describe("P-MySQL Service broker", func() {
 	It("Registers a route", func() {
-		uri := fmt.Sprintf("https://%s/v2/catalog", helpers.TestConfig.BrokerHost)
+		uri := fmt.Sprintf("%s://%s/v2/catalog", helpers.TestConfig.BrokerProtocol, helpers.TestConfig.BrokerHost)
 
 		fmt.Printf("\n*** Curling url: %s\n", uri)
 		curlCmd := runner.NewCmdRunner(runner.Curl("-k", uri), helpers.TestContext.ShortTimeout()).Run()

--- a/cf-mysql-service/failover/failover_test.go
+++ b/cf-mysql-service/failover/failover_test.go
@@ -66,7 +66,7 @@ var _ = Describe("CF MySQL Failover", func() {
 		appName = generator.RandomName()
 
 		By("Push an app", func() {
-			runner.NewCmdRunner(Cf("push", appName, "-m", "256M", "-p", sinatraPath, "-no-start"), helpers.TestContext.LongTimeout()).Run()
+			runner.NewCmdRunner(Cf("push", appName, "-m", "256M", "-p", sinatraPath, "-b", "ruby_buildpack", "-no-start"), helpers.TestContext.LongTimeout()).Run()
 		})
 	})
 

--- a/cf-mysql-service/lifecycle/lifecycle_test.go
+++ b/cf-mysql-service/lifecycle/lifecycle_test.go
@@ -32,7 +32,7 @@ var _ = Describe("P-MySQL Lifecycle Tests", func() {
 			}
 
 			appName := RandomName()
-			pushCmd := runner.NewCmdRunner(Cf("push", appName, "-m", "256M", "-p", sinatraPath, "-no-start"), helpers.TestContext.LongTimeout()).Run()
+			pushCmd := runner.NewCmdRunner(Cf("push", appName, "-m", "256M", "-p", sinatraPath, "-b", "ruby_buildpack", "-no-start"), helpers.TestContext.LongTimeout()).Run()
 			Expect(pushCmd).To(Say("OK"))
 
 			serviceInstanceName := RandomName()

--- a/cf-mysql-service/quota/quota_test.go
+++ b/cf-mysql-service/quota/quota_test.go
@@ -43,7 +43,7 @@ var _ = Describe("P-MySQL Service", func() {
 			plan = helpers.TestConfig.Plans[0]
 
 			serviceURI = fmt.Sprintf("%s/service/mysql/%s", helpers.TestConfig.AppURI(appName), serviceInstanceName)
-			runner.NewCmdRunner(Cf("push", appName, "-m", "256M", "-p", sinatraPath, "-no-start"), helpers.TestContext.LongTimeout()).Run()
+			runner.NewCmdRunner(Cf("push", appName, "-m", "256M", "-p", sinatraPath, "-b", "ruby_buildpack", "-no-start"), helpers.TestContext.LongTimeout()).Run()
 		})
 
 		JustBeforeEach(func() {

--- a/helpers/config.go
+++ b/helpers/config.go
@@ -24,8 +24,8 @@ type Proxy struct {
 	APIUsername       string   `json:"api_username"`
 	APIPassword       string   `json:"api_password"`
 	SkipSSLValidation bool     `json:"skip_ssl_validation"`
-	ForceHTTPS        bool     `json:"api_force_https"`
 }
+
 type Standalone struct {
 	Host          string `json:"host"`
 	MySQLUsername string `json:"username"`
@@ -35,13 +35,14 @@ type Standalone struct {
 
 type MysqlIntegrationConfig struct {
 	services.Config
-	BrokerHost  string      `json:"broker_host"`
-	ServiceName string      `json:"service_name"`
-	Plans       []Plan      `json:"plans"`
-	Brokers     []Component `json:"brokers"`
-	MysqlNodes  []Component `json:"mysql_nodes"`
-	Proxy       Proxy       `json:"proxy"`
-	Standalone  Standalone  `json:"standalone"`
+	BrokerHost     string      `json:"broker_host"`
+	BrokerProtocol string      `json:"broker_protocol"`
+	ServiceName    string      `json:"service_name"`
+	Plans          []Plan      `json:"plans"`
+	Brokers        []Component `json:"brokers"`
+	MysqlNodes     []Component `json:"mysql_nodes"`
+	Proxy          Proxy       `json:"proxy"`
+	Standalone     Standalone  `json:"standalone"`
 }
 
 func (c MysqlIntegrationConfig) AppURI(appname string) string {
@@ -59,6 +60,10 @@ func LoadConfig() (MysqlIntegrationConfig, error) {
 	err := services.LoadConfig(path, &config)
 	if err != nil {
 		return config, fmt.Errorf("Loading config: %s", err.Error())
+	}
+
+	if config.BrokerProtocol == "" {
+		config.BrokerProtocol = "https"
 	}
 
 	return config, nil


### PR DESCRIPTION
MicroPCF needs to run these tests against a broker only listening on HTTP. We made the property configurable but default to https so that existing behavior is preserved. We also removed an unused config property (ForceHTTPS) and specified the buildpack when pushing the sample app to speed up the tests.

@ekcasey and @mdelillo